### PR TITLE
Bytt til nytt PAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: gradle build
       - name: integration tests
         env:
-          PAT_READ_TOKEN: ${{ secrets.READ_PACKAGES_PAT }}
+          PAT_READ_TOKEN: ${{ secrets.READER_TOKEN }}
         run: |
           set -e
           echo "$PAT_READ_TOKEN" | docker login -u USERNAME --password-stdin ghcr.io


### PR DESCRIPTION
Vi er i ferd med å fase ut READ_PACKAGES_PAT, og ønsker derfor at dere bruker READER_TOKEN i stedet.
