### PR TITLE
Kommenterer ut setting av alias ved oppstart

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsplassen/internalad/indexer/index/AdTopicListener.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/internalad/indexer/index/AdTopicListener.kt
@@ -38,7 +38,7 @@ class AdTopicListener(private val indexerService: IndexerService,
 
     private fun initIndex() {
         indexerService.initIndex(indexName)
-        indexerService.initAlias(indexName)
+        //indexerService.initAlias(indexName)
         LOG.info("Will index to $indexName")
     }
 


### PR DESCRIPTION
Skrur av setting av alias slik at pam-stilling-opensearch-indekser kan ta over jobben uten at den gamle indeksen slutter å indeksere (i tilfelle noe går galt)